### PR TITLE
Use the installation path as default config path

### DIFF
--- a/openzwave-sys/src/lib.rs
+++ b/openzwave-sys/src/lib.rs
@@ -6,6 +6,16 @@ pub mod options;
 pub mod notification;
 pub mod value_classes;
 
+use std::path::PathBuf;
+
+pub fn get_default_config_path() -> PathBuf {
+    let installed_path = env!("CARGO_MANIFEST_DIR");
+    let mut installed_path = PathBuf::from(installed_path);
+    installed_path.push("open-zwave");
+    installed_path.push("config");
+    installed_path
+}
+
 #[cfg(test)]
 mod test {
     #[test]

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,4 +1,5 @@
 use ffi::options as extern_options;
+use ffi::get_default_config_path;
 use std::ffi::CString;
 use ffi::utils::res_to_result;
 use error::{ Result, Error };
@@ -9,7 +10,12 @@ pub struct Options {
 
 impl Options {
     pub fn create(config_path: &str, user_path: &str, command_line: &str) -> Result<Options> {
-        let config_path_c = CString::new(config_path).unwrap();
+        let config_path_c = if config_path.is_empty() {
+            CString::new(&*get_default_config_path().to_string_lossy())
+        } else {
+            CString::new(config_path)
+        }.unwrap();
+
         let user_path_c = CString::new(user_path).unwrap();
         let command_line_c = CString::new(command_line).unwrap();
         let external_options = unsafe {


### PR DESCRIPTION
This should let us use the config files directly from open-zwave, while still allowing the directory to be specified at startup.
